### PR TITLE
Fix share and update shopping list (only owner)

### DIFF
--- a/personal/templates/pages/detail/shopping_list.html
+++ b/personal/templates/pages/detail/shopping_list.html
@@ -12,7 +12,11 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
-        {% include 'components/header/system.html' with title=shopping_list.name icon_left="shopping" share=share icon_share_url="list_share" icon_share_pk=shopping_list.pk icon_right="pencil" icon_right_url="list_update" icon_right_pk=shopping_list.pk %}
+        {% if request.user == shopping_list.owner %}
+            {% include 'components/header/system.html' with title=shopping_list.name icon_left="shopping" share=share icon_share_url="list_share" icon_share_pk=shopping_list.pk icon_right="pencil" icon_right_url="list_update" icon_right_pk=shopping_list.pk %}
+        {% else %}
+            {% include 'components/header/system.html' with title=shopping_list.name icon_left="shopping" %}
+        {% endif %}
         <main>
             {% include 'components/grid/shopping_list_item.html' %}
         </main>

--- a/personal/views.py
+++ b/personal/views.py
@@ -94,7 +94,7 @@ class ShoppingListView(LoginRequiredMixin, LegalRequirementMixin, generic.Detail
             status="in_progress"
         )
         context["items_done"] = shopping_list.shoppinglistitem_set.filter(status="done")
-        context["share"] = True
+        context["share"] = shopping_list.owner == self.request.user
         return context
 
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
## Description
The issue was fixed by modifying the user interface so that the edit icon and the sharing option are only visible to the owner of the shopping list. This ensures that only the list's owner can make edits and share it with others.

## Screenshot
<img width="418" alt="Screenshot 2024-08-25 at 07 59 05" src="https://github.com/user-attachments/assets/f49f13bf-e0e0-4933-9487-c7c634e92827">
<img width="417" alt="Screenshot 2024-08-25 at 07 58 55" src="https://github.com/user-attachments/assets/e582e83f-f27d-482a-93ef-f852185c3701">
<img width="418" alt="Screenshot 2024-08-25 at 07 58 42" src="https://github.com/user-attachments/assets/a926549d-9e5e-4f72-8f14-fbfbe94851cb">
