### PR TITLE
Redirect user to home if user is not owner

### DIFF
--- a/personal/views.py
+++ b/personal/views.py
@@ -125,6 +125,12 @@ class UpdateShoppingListView(
         context["list"] = shopping_list
         return context
 
+    def dispatch(self, request, *args, **kwargs):
+        shopping_list = self.get_object()
+        if shopping_list.owner != request.user:
+            return redirect(reverse("home"))
+        return super().dispatch(request, *args, **kwargs)
+
     def form_valid(self, form):
         form.instance.owner = self.request.user
         return super().form_valid(form)
@@ -138,6 +144,12 @@ class DeleteShoppingListView(LoginRequiredMixin, generic.DeleteView):
     template_name = "pages/root/account_delete.html"
     success_url = reverse_lazy("lists")
     login_url = reverse_lazy("login")
+
+    def dispatch(self, request, *args, **kwargs):
+        shopping_list = self.get_object()
+        if shopping_list.owner != request.user:
+            return redirect(reverse("home"))
+        return super().dispatch(request, *args, **kwargs)
 
 
 class ShareShoppingListView(
@@ -164,6 +176,12 @@ class ShareShoppingListView(
         shopping_list.shared_with.set(shared_users)
 
         return redirect("list", pk=shopping_list.pk)
+
+    def dispatch(self, request, *args, **kwargs):
+        shopping_list = self.get_object()
+        if shopping_list.owner != request.user:
+            return redirect(reverse("home"))
+        return super().dispatch(request, *args, **kwargs)
 
 
 class SelectShoppingListView(


### PR DESCRIPTION
## Description
Introduce a new validation step to ensure that only the owner of a shopping list can access specific views related to that list. If a user who is not the owner tries to access these views, they will be redirected to the homepage. This enhances the security and privacy of the shopping lists by preventing unauthorized access.

- Add a check in the `dispatch` method of relevant views to verify if the current user is the owner of the shopping list.
- If the user is not the owner, they are redirected to the homepage.