### PR TITLE
Implement mobile-only error message.

### DIFF
--- a/personal/templates/pages/categories.html
+++ b/personal/templates/pages/categories.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' with icon_left=category.icon title=category.name %}
         <main>
             {% include 'components/grid/category.html' %}

--- a/personal/templates/pages/category.html
+++ b/personal/templates/pages/category.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' with icon_left=category.icon title=category.name %}
         <main>
             {% include 'components/search/foods.html' %}

--- a/personal/templates/pages/create/note.html
+++ b/personal/templates/pages/create/note.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/create.html' with title=title model="note" %}

--- a/personal/templates/pages/create/shopping_list.html
+++ b/personal/templates/pages/create/shopping_list.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/create.html' with title=title model="shopping_list" %}

--- a/personal/templates/pages/create/shopping_list_item.html
+++ b/personal/templates/pages/create/shopping_list_item.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/create.html' with title=title model="shopping_list_item" operation=operation %}

--- a/personal/templates/pages/create/task.html
+++ b/personal/templates/pages/create/task.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/create.html' with title=title model="task" %}

--- a/personal/templates/pages/detail/shopping_list.html
+++ b/personal/templates/pages/detail/shopping_list.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% if request.user == shopping_list.owner %}
             {% include 'components/header/system.html' with title=shopping_list.name icon_left="shopping" share=share icon_share_url="list_share" icon_share_pk=shopping_list.pk icon_right="pencil" icon_right_url="list_update" icon_right_pk=shopping_list.pk %}
         {% else %}

--- a/personal/templates/pages/notes.html
+++ b/personal/templates/pages/notes.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' with icon_right="plus" icon_right_url="note_create" %}
         <main>
             {% include 'components/grid/note.html' %}

--- a/personal/templates/pages/select_shopping_list.html
+++ b/personal/templates/pages/select_shopping_list.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/grid/select_list.html' %}

--- a/personal/templates/pages/share_shopping_list.html
+++ b/personal/templates/pages/share_shopping_list.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' with icon_right="plus" icon_right_url="list_create" %}
         <main>
             {% include 'components/grid/share_users.html' %}

--- a/personal/templates/pages/shopping_list.html
+++ b/personal/templates/pages/shopping_list.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' with icon_right="plus" icon_right_url="list_create" %}
         <main>
             {% include 'components/grid/list.html' %}

--- a/system/static/css/global.css
+++ b/system/static/css/global.css
@@ -25,6 +25,10 @@ main {
     overflow-y: auto;
 }
 
+.mobile-only {
+    display: None;
+}
+
 .swiss {
     color: red;
     font-weight: bold;
@@ -116,7 +120,7 @@ main {
     font-size: 0.7rem;
 }
 
-.card .bold {
+.bold {
     font-weight: bold;
 }
 
@@ -639,4 +643,33 @@ main {
     margin-left: 16px;
     font-size: 0.8rem;
     color: #717171;
+}
+
+@media only screen and (min-width: 750px) {
+    .mobile-only {
+        z-index: 1;
+        display: flex;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background-color: #ffbeb3;
+    }
+
+    .mobile-only .message {
+        margin: 128px auto auto auto;
+        background-color: white;
+        padding: 16px;
+        border-radius: 10px;
+        width: 500px;
+    }
+
+    .mobile-only .title {
+        font-size: 1.5rem;
+    }
+
+    .mobile-only p {
+        display: flex;
+        justify-content: center;
+    }
+
 }

--- a/system/templates/components/errors/mobile.html
+++ b/system/templates/components/errors/mobile.html
@@ -1,0 +1,8 @@
+{% load static %}
+{% load i18n %}
+<div class="mobile-only">
+    <div class="message">
+        <p class="title bold">{% translate 'Hinweis' %}</p>
+        <p class="color-red">{% translate 'Zurzeit nur auf mobilen Ansicht verfügbar!' %}</p>
+    </div>
+</div>

--- a/system/templates/pages/authentication/login.html
+++ b/system/templates/pages/authentication/login.html
@@ -11,6 +11,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/authentication.html' with auth_type="login" %}

--- a/system/templates/pages/authentication/signup.html
+++ b/system/templates/pages/authentication/signup.html
@@ -11,6 +11,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/authentication.html' with auth_type="signup" %}

--- a/system/templates/pages/legal/disclaimer.html
+++ b/system/templates/pages/legal/disclaimer.html
@@ -11,6 +11,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/disclaimer.html' %}

--- a/system/templates/pages/legal/impressum.html
+++ b/system/templates/pages/legal/impressum.html
@@ -11,6 +11,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/impressum.html' %}

--- a/system/templates/pages/legal/privacy.html
+++ b/system/templates/pages/legal/privacy.html
@@ -11,6 +11,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/privacy.html' %}

--- a/system/templates/pages/legal/terms.html
+++ b/system/templates/pages/legal/terms.html
@@ -11,6 +11,8 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
+
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/cards/terms.html' %}

--- a/system/templates/pages/root/home.html
+++ b/system/templates/pages/root/home.html
@@ -12,6 +12,7 @@
         <title>{% translate 'Home' %}</title>
     </head>
     <body>
+        {% include 'components/errors/mobile.html' %}
         {% include 'components/header/system.html' %}
         <main>
             {% include 'components/grid/home.html' %}


### PR DESCRIPTION
## Description
Implement a mobile-only error message. The error message informs users accessing the site from non-mobile devices that the site is currently only available on mobile.

## Notice
⚠️ This will exist temporarily. As soon as the desktop view is correctly implemented, it will be removed.

## Screenshot
<img width="1920" alt="Screenshot 2024-09-01 at 18 14 09" src="https://github.com/user-attachments/assets/bd4e8a1b-f346-4f79-aa74-ea54c83d1b57">
