### PR TITLE
Change error message for username

### DIFF
--- a/system/forms.py
+++ b/system/forms.py
@@ -32,11 +32,11 @@ class SignUpForm(ModelForm):
             raise forms.ValidationError("Username ist ein Pflichtfeld")
         if " " in username:
             raise forms.ValidationError(
-                "Benutzername ist nur diese Format ist erlaubt 'vorname_nachname'. Daten von Majestic!"
+                "Benutzername darf weder Sonderzeichen, Lücken, noch Grossbuchstaben enthalten."
             )
         if not re.match("^[a-z0-9_.]+$", username):
             raise forms.ValidationError(
-                "Benutzername ist nur diese Format ist erlaubt 'vorname_nachname'. Daten von Majestic!"
+                "Benutzername darf weder Sonderzeichen, Lücken, noch Grossbuchstaben enthalten."
             )
         return username.lower()
 


### PR DESCRIPTION
## Description
Updated the error message related to username validation in a form. The new message clarifies that the username should not contain special characters, spaces, or uppercase letters. The previous error message, which referenced a specific format and external data source, has been replaced (which contained false information) with this clearer instruction.

## Screenshots
<img width="355" alt="Screenshot 2024-09-02 at 01 44 10" src="https://github.com/user-attachments/assets/a965c0c8-c2c0-45ac-b383-1b8b02da3d4c">
