### PR TITLE
Fix grammatical errors in the imprint

### DIFF
--- a/system/templates/components/cards/disclaimer.html
+++ b/system/templates/components/cards/disclaimer.html
@@ -7,7 +7,7 @@
     <div class="main legalify">
         <p>
             <span class="bold">{% translate '1. Inhalt des Onlineangebots' %}</span><br>
-            {% translate 'Die Inhalte dieser Webseite wurden mit grösstmöglicher Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen. Als Dienstanbieter sind wir gemäss § 7 Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.' %}
+            {% translate 'Die Inhalte dieser Webapplikation wurden mit grösstmöglicher Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen. Als Dienstanbieter sind wir gemäss § 7 Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.' %}
         </p>
         <p>
             <span class="bold">{% translate '2. Haftung für Links' %}</span><br>
@@ -19,11 +19,11 @@
         </p>
         <p>
             <span class="bold">{% translate '4. Haftung für Schäden' %}</span><br>
-            {% translate 'Wir schliessen jegliche Haftung für Schäden aus, die direkt oder indirekt aus der Nutzung dieser Webseite und der darin enthaltenen Informationen entstehen, soweit diese nicht auf Vorsatz oder grober Fahrlässigkeit beruhen.' %}
+            {% translate 'Wir schliessen jegliche Haftung für Schäden aus, die direkt oder indirekt aus der Nutzung dieser Webapplikation und der darin enthaltenen Informationen entstehen, soweit diese nicht auf Vorsatz oder grober Fahrlässigkeit beruhen.' %}
         </p>
         <p>
             <span class="bold">{% translate '5. Keine Abmahnung ohne vorherigen Kontakt' %}</span><br>
-            {% translate 'Sollten Inhalte dieser Webseite die Rechte Dritter oder gesetzliche Bestimmungen verletzen, bitten wir um eine entsprechende Nachricht ohne Kostennote. Wir garantieren, dass die zu Recht beanstandeten Inhalte unverzüglich entfernt werden, ohne dass die Einschaltung eines Rechtsbeistandes erforderlich ist. Dennoch von Ihnen ohne vorherige Kontaktaufnahme ausgelöste Kosten werden wir vollständig zurückweisen und gegebenenfalls Gegenklage wegen Verletzung vorgenannter Bestimmungen einreichen.' %}
+            {% translate 'Sollten Inhalte dieser Webapplikation die Rechte Dritter oder gesetzliche Bestimmungen verletzen, bitten wir um eine entsprechende Nachricht ohne Kostennote. Wir garantieren, dass die zu Recht beanstandeten Inhalte unverzüglich entfernt werden, ohne dass die Einschaltung eines Rechtsbeistandes erforderlich ist. Dennoch von Ihnen ohne vorherige Kontaktaufnahme ausgelöste Kosten werden wir vollständig zurückweisen und gegebenenfalls Gegenklage wegen Verletzung vorgenannter Bestimmungen einreichen.' %}
         </p>
     </div>
     <div class="action">

--- a/system/templates/components/cards/impressum.html
+++ b/system/templates/components/cards/impressum.html
@@ -5,7 +5,7 @@
         <h1>{% translate 'Impressum' %}</h1>
     </div>
     <div class="main legalify legalify-bottom">
-        <p class="bold">{% translate 'Verantwortluch für den Inhalt gemäss § 5 TMG (Telemediengesetz) und Art. 4 Abs. 7 DSGVO' %}</p>
+        <p class="bold">{% translate 'Verantwortlich für den Inhalt gemäss § 5 TMG (Telemediengesetz) und Art. 4 Abs. 7 DSGVO' %}</p>
         <p>
             Gian Erler<br>
             Schweiz<br>
@@ -32,7 +32,7 @@
         </p>
         <p>
             <span class="bold">{% translate 'Obligatorische Sponsorhinweis' %}</span><br>
-            Diese Webseite wird <span style="color: #FF9900">gesponsert von</span> <span class="bold"><span style="color: #004CBC">K</span><span style="color: #FF0000">i</span><span style="color: #FF9900">i</span><span style="color: #004CBC">d</span><span style="color: #00B749">l</span><span style="color: #FF0000">e</span></span>. Der Hinweis auf den Sponsor ist hier aufgrund der geltenden Impressumspflicht der Europäischen Union und der Schweiz enthalten. Es besteht keine weitere rechtliche oder geschäftliche Beziehung zwischen dem Betreiber dieser Seite und dem Sponsor.
+            Diese Webapplikation wird <span style="color: #FF9900">gesponsert von</span> <span class="bold"><span style="color: #004CBC">K</span><span style="color: #FF0000">i</span><span style="color: #FF9900">i</span><span style="color: #004CBC">d</span><span style="color: #00B749">l</span><span style="color: #FF0000">e</span></span>. Der Hinweis auf den Sponsor ist hier aufgrund der geltenden Impressumspflicht der Europäischen Union und der Schweiz enthalten. Es besteht keine weitere rechtliche oder geschäftliche Beziehung zwischen dem Betreiber dieser Seite und dem Sponsor.
         </p>
         <div class="swiss">
             <div class="swiss-top">

--- a/system/templates/components/cards/privacy.html
+++ b/system/templates/components/cards/privacy.html
@@ -21,16 +21,16 @@
         </p>
         <p>
             <span class="bold">{% translate '2. Zweck der Datenverarbeitung' %}</span><br>
-            {% translate 'Dieses Projekt ist ein rein schulsisches Vorhaben und dient ausschliesslich zu Bildungszwecken. Wir erheben und verarbeiten personenbezogene Daten nur in dem Umfang, der für die Nutzung dieser Webseite erforderlich ist.' %}
+            {% translate 'Dieses Projekt ist ein rein schulisches Vorhaben und dient ausschliesslich zu Bildungszwecken. Wir erheben und verarbeiten personenbezogene Daten nur in dem Umfang, der für die Nutzung dieser Webapplikation erforderlich ist.' %}
         </p>
         <p>
             <span class="bold">{% translate '3. Erhobene Daten' %}</span><br>
-            <span class="bold">- {% translate 'Server-Log Dateien' %}:</span>{% translate ' Beim unserer Webseite werden automatisch Informationen durch den Webserver in sogenannten Log-Dateien gespeichert. Diese beinhalten die IP-Adresse, den Browsertyp, das Betriebssystem, die Refferrer-URL, potenziell teile des Browserverlauf, sowie das Datum und die Uhrzeit des Zugriffs. Diese Daten werden nicht weitergegeben.' %}<br>
-            <span class="bold">- {% translate 'Cookies' %}:</span>{% translate ' Diese Webseite verwendet keine nicht-technische Cookies.' %}
+            <span class="bold">- {% translate 'Server-Log Dateien' %}:</span>{% translate ' Beim unserer Webapplikation werden automatisch Informationen durch den Webserver in sogenannten Log-Dateien gespeichert. Diese beinhalten die IP-Adresse, den Browsertyp, das Betriebssystem, die Refferrer-URL, potenziell teile des Browserverlauf, sowie das Datum und die Uhrzeit des Zugriffs. Diese Daten werden nicht weitergegeben.' %}<br>
+            <span class="bold">- {% translate 'Cookies' %}:</span>{% translate ' Diese Webapplikation verwendet keine nicht-technische Cookies.' %}
         </p>
         <p>
             <span class="bold">{% translate '4. Rechtsgrundlage' %}</span><br>
-            {% translate 'Die Verarbeitung der genannten Daten erfolgt gemäss Art. 6 Abs. 1 lit. f DSGVO, wobei unser berechtigtes Interesse darin besteht, eine funktionsfähige und benutzerfreundliche Webseite zu betreiben.' %}
+            {% translate 'Die Verarbeitung der genannten Daten erfolgt gemäss Art. 6 Abs. 1 lit. f DSGVO, wobei unser berechtigtes Interesse darin besteht, eine funktionsfähige und benutzerfreundliche Webapplikation zu betreiben.' %}
         </p>
         <p>
             <span class="bold">{% translate '5. Dauer der Speicherung' %}</span><br>
@@ -46,7 +46,7 @@
         </p>
         <p>
             <span class="bold">{% translate '8. Änderung der Datenschutzerklärung' %}</span><br>
-            {% translate 'Wir behalten uns vor, diese Datenschutzerklärung zu ändern, um sie an aktuelle rechtliche Anforderungen oder Änderungen unserer Leistungen anzupassen. Die jeweils aktuelle Fassung ist jederzeit auf dieser Webseite abrufbar.' %}
+            {% translate 'Wir behalten uns vor, diese Datenschutzerklärung zu ändern, um sie an aktuelle rechtliche Anforderungen oder Änderungen unserer Leistungen anzupassen. Die jeweils aktuelle Fassung ist jederzeit auf dieser Webapplikation abrufbar.' %}
         </p>
     </div>
     <div class="action">

--- a/system/templates/components/cards/terms.html
+++ b/system/templates/components/cards/terms.html
@@ -7,12 +7,12 @@
     <div class="main legalify">
         <p>
             <span class="bold">{% translate '1. Allgemeine Grundsätze' %}</span><br>
-            {% translate 'Diese Webseite ist ein schulisches Projekt und dient ausschliesslich zu Bildungszwecken. Die Nutzung der Webseite unterliegt diesen Nutzungsrichtlinien, die jederzeit von den Verantwortlichen angepasst werden können. Mit der Nutzung der Webseite stimmen Sie diesen Nutzungsrichtlinien zu.' %}
+            {% translate 'Diese Webapplikation ist ein schulisches Projekt und dient ausschliesslich zu Bildungszwecken. Die Nutzung der Webapplikation unterliegt diesen Nutzungsrichtlinien, die jederzeit von den Verantwortlichen angepasst werden können. Mit der Nutzung der Webapplikation stimmen Sie diesen Nutzungsrichtlinien zu.' %}
         </p>
         <p>
             <span class="bold">{% translate '2. Verhaltensregeln' %}</span><br>
-           {% translate 'Um eine sichere und respektvolle Umgebung für alle Benutzer zu gewährleisten, sind die folgenden Verhaltensweisen auf dieser Webseite strengstens untersagt:' %}<br>
-            <span class="bold">- {% translate 'Missbrauch von Privilegien (ABUSE)' %}:</span> {% translate 'Jede Form der ungerechtfertigten Ausnutzung von Rechten oder Zugriffsrechten auf dieser Webseite.' %}<br>
+           {% translate 'Um eine sichere und respektvolle Umgebung für alle Benutzer zu gewährleisten, sind die folgenden Verhaltensweisen auf dieser Webapplikation strengstens untersagt:' %}<br>
+            <span class="bold">- {% translate 'Missbrauch von Privilegien (ABUSE)' %}:</span> {% translate 'Jede Form der ungerechtfertigten Ausnutzung von Rechten oder Zugriffsrechten auf dieser Webapplikation.' %}<br>
             <span class="bold">- {% translate 'Antisemitismus (ANTISEMITISM)' %}:</span> {% translate 'Jegliche Form von antisemitischer Äusserung oder Handlung.' %}<br>
             <span class="bold">- {% translate 'Erpressung (BLACKMAILING)' %}:</span> {% translate 'Jede Handlung, bei der eine Person durch Androhung von Nachteilen zu etwas gezwungen wird.' %}<br>
             <span class="bold">- {% translate 'Cybermobbing (BULLYING)' %}:</span> {% translate 'Belästigung oder Mobbing anderer Benutzer durch verletzende oder beleidigende Inhalte.' %}<br>
@@ -43,7 +43,7 @@
         </p>
         <p>
             <span class="bold">{% translate '3. Konsequenzen bei Verstösse' %}</span><br>
-            {% translate 'Verstösse gegen diese Nutzungsrichtlinien können zur vorübergehenden oder dauerhaften Sperrung des Zugangs zur Webseite führen. Die Verantwortlichen behalten sich das Recht vor, bei schwerwiegenden Verstössen rechtliche Schritte einzuleiten.' %}
+            {% translate 'Verstösse gegen diese Nutzungsrichtlinien können zur vorübergehenden oder dauerhaften Sperrung des Zugangs zur Webapplikation führen. Die Verantwortlichen behalten sich das Recht vor, bei schwerwiegenden Verstössen rechtliche Schritte einzuleiten.' %}
         </p>
         <p>
             <span class="bold">{% translate '4. Meldung von Verstösse' %}</span><br>
@@ -51,7 +51,7 @@
         </p>
         <p>
             <span class="bold">{% translate '5. Änderung der Nutzungsrichtlinien' %}</span><br>
-            {% translate 'Wir behalten uns das Recht vor, diese Nutzungsrichtlinien jederzeit zu ändern oder zu aktualisieren. Die jeweils aktuelle Fassung ist auf dieser Webseite einsehbar und gilt ab dem Zeitpunkt der Veröffentlichung.' %}
+            {% translate 'Wir behalten uns das Recht vor, diese Nutzungsrichtlinien jederzeit zu ändern oder zu aktualisieren. Die jeweils aktuelle Fassung ist auf dieser Webapplikation einsehbar und gilt ab dem Zeitpunkt der Veröffentlichung.' %}
         </p>
     </div>
     <div class="action">


### PR DESCRIPTION
## Description
Fix grammatical errors in the imprint and updating the terminology.
- `Verantwortluchen` -> `Verantwortlichen`
- `schulsisches` -> `schulisches`
- `Webseite` -> `Webapplikation`