### PR TITLE
Fix Task status default

### DIFF
--- a/personal/migrations/0010_alter_task_status_default.py
+++ b/personal/migrations/0010_alter_task_status_default.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("personal", "0009_alter_shoppinglistitem_unit_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="task",
+            name="status",
+            field=models.BooleanField(default=False, verbose_name="Status"),
+        ),
+    ]
+

--- a/personal/models.py
+++ b/personal/models.py
@@ -116,7 +116,7 @@ class Task(models.Model):
     text = models.CharField(verbose_name=_("Titel"), max_length=50)
     status = models.BooleanField(
         verbose_name=_("Status"),
-        default="false",
+        default=False,
     )
 
     owner = models.ForeignKey(


### PR DESCRIPTION
## Summary
- fix `Task.status` default value to be boolean
- add migration to correct existing default

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'configurations')*

------
https://chatgpt.com/codex/tasks/task_e_684adcf3ba0883208285699180d7fe4c